### PR TITLE
feat: add Projects section featuring GitManager

### DIFF
--- a/content/projects/cloud-costs-app.md
+++ b/content/projects/cloud-costs-app.md
@@ -1,7 +1,7 @@
 ---
 title: "Cloud Costs Dashboard"
 date: 2024-07-01
-draft: false
+draft: true
 emoji: "💰"
 github_repo: "https://github.com/grabskimm/cloud-costs-dashboard"
 description: "Customized Azure Cloud Costs Dashboard | Lead strategic centralized cost management and optimization efforts. "

--- a/content/projects/git-manager.md
+++ b/content/projects/git-manager.md
@@ -1,0 +1,11 @@
+---
+title: "GitManager"
+date: 2026-06-23
+draft: false
+emoji: "🔀"
+github_repo: "https://github.com/grabskimm/git-manager"
+live_url: "https://gitm.mendelg.tech"
+description: "Local-first, GitHub-style UI over the git repos that live only on your machine — local pull requests, automatic Claude code review before merge, a built-in terminal, and optional cloud backup. Everything runs on loopback; no server, no telemetry."
+tags: ["TypeScript", "React", "Fastify", "SQLite", "Electron", "Local-First"]
+weight: 10
+---

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -2,5 +2,5 @@
     {{ partial "about.html" . }}
     {{ partial "experience.html" . }}
     {{ partial "certs.html" . }}
-    <!-- {{ partial "projects.html" . }} -->
+    {{ partial "projects.html" . }}
 {{ end }}

--- a/layouts/partials/projects.html
+++ b/layouts/partials/projects.html
@@ -13,6 +13,11 @@
                 <span class="tag">{{ . }}</span>
                 {{ end }}
             </div>
+            {{ with .Params.live_url }}
+            <div class="project-links">
+                <a href="{{ . }}" target="_blank" rel="noopener noreferrer" class="project-link">Visit site &rarr;</a>
+            </div>
+            {{ end }}
         </div>
         {{ end }}
     </div>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -299,6 +299,22 @@ p {
     margin-bottom: 5px;
 }
 
+.project-links {
+    margin-top: 15px;
+}
+
+.project-link {
+    font-family: 'Fira Code', monospace;
+    font-size: 0.85rem;
+    color: var(--accent-color);
+    text-decoration: none;
+    transition: opacity var(--transition-speed) ease;
+}
+
+.project-link:hover {
+    opacity: 0.75;
+}
+
 /* Calendly badge widget font override - use monospace CTA font for the badge */
 [class*="calendly"], [class^="calendly"], .calendly-badge-widget, .calendly-badge {
     font-family: 'Fira Code', monospace !important;


### PR DESCRIPTION
## Summary

Re-enables the homepage **Projects** section (previously commented out in `layouts/index.html` during a past refactor) and adds the **GitManager** project as its lead entry.

## Changes

- **Re-enable Projects section** — uncomment the `projects.html` partial in `layouts/index.html`.
- **Add GitManager project** — `content/projects/git-manager.md` (`weight: 10`, so it leads the grid). Links to the repo at `github.com/grabskimm/git-manager` and the live site `gitm.mendelg.tech`.
- **Optional live-site link** — the project card now renders a "Visit site →" link when a `live_url` param is present (backwards-compatible; existing cards without it are unaffected). Added matching `.project-link` / `.project-links` CSS.
- **Hide Cloud Costs Dashboard for now** — marked `draft: true`. Content is preserved; flip back to `draft: false` later to re-add it.

## Testing

- `hugo --gc` builds cleanly (pre-existing section/taxonomy layout warnings are unrelated).
- Verified the rendered `public/index.html`: the `#projects` section is present, GitManager renders with its repo link, tags, and the `gitm.mendelg.tech` "Visit site" link; Cloud Costs Dashboard is correctly excluded as a draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWj4XJtH8LEcPvqENLEyDn)_