### PR TITLE
feat: redesign partners section as compact numbered cards

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -8,15 +8,19 @@ title = "Mendel Grabski | Cloud Security Architect"
   linkedin = "https://www.linkedin.com/in/mendel-grabski/"
 
   # Repositories and sites partnered with in the past.
-  # NOTE: placeholder entries — replace name/url with the real list when provided.
+  # NOTE: placeholder entries — replace name/note/url with the real list when provided.
+  # `note` is a short context line (the relationship or what the project is).
   [[params.partners]]
     name = "Partner Project One"
+    note = "Open-source collaboration"
     url = "#"
   [[params.partners]]
     name = "Partner Project Two"
+    note = "Design & brand studio"
     url = "#"
   [[params.partners]]
     name = "Partner Project Three"
+    note = "Infrastructure & tooling"
     url = "#"
 
 [taxonomies]

--- a/layouts/partials/partners.html
+++ b/layouts/partials/partners.html
@@ -1,19 +1,22 @@
 <section id="partners" class="partners">
     <h2>Projects, Continued</h2>
     <p class="partners-intro">Repositories and sites I've partnered with in the past.</p>
-    <ul class="partners-list">
-        {{ range .Site.Params.partners }}
-        <li>
-            {{ if and .url (ne .url "#") }}
-            <a href="{{ .url }}" target="_blank" rel="noopener noreferrer">
-                <i class="fas fa-link" aria-hidden="true"></i>{{ .name }}
-            </a>
-            {{ else }}
-            <span class="partner-placeholder" aria-disabled="true" title="Coming soon">
-                <i class="fas fa-link" aria-hidden="true"></i>{{ .name }}
-            </span>
-            {{ end }}
-        </li>
+    <div class="partners-grid">
+        {{ range $i, $p := .Site.Params.partners }}
+        {{ if and $p.url (ne $p.url "#") }}
+        <a class="partner-card" href="{{ $p.url }}" target="_blank" rel="noopener noreferrer">
+            <span class="partner-num">{{ printf "%02d" (add $i 1) }}</span>
+            <span class="partner-name">{{ $p.name }}</span>
+            {{ with $p.note }}<span class="partner-note">{{ . }}</span>{{ end }}
+            <i class="fas fa-arrow-right partner-arrow" aria-hidden="true"></i>
+        </a>
+        {{ else }}
+        <div class="partner-card partner-card--placeholder" aria-disabled="true" title="Coming soon">
+            <span class="partner-num">{{ printf "%02d" (add $i 1) }}</span>
+            <span class="partner-name">{{ $p.name }}</span>
+            {{ with $p.note }}<span class="partner-note">{{ . }}</span>{{ end }}
+        </div>
         {{ end }}
-    </ul>
+        {{ end }}
+    </div>
 </section>

--- a/layouts/partials/partners.html
+++ b/layouts/partials/partners.html
@@ -11,7 +11,7 @@
             <i class="fas fa-arrow-right partner-arrow" aria-hidden="true"></i>
         </a>
         {{ else }}
-        <div class="partner-card partner-card--placeholder" aria-disabled="true" title="Coming soon">
+        <div class="partner-card partner-card--placeholder" title="Coming soon">
             <span class="partner-num">{{ printf "%02d" (add $i 1) }}</span>
             <span class="partner-name">{{ $p.name }}</span>
             {{ with $p.note }}<span class="partner-note">{{ . }}</span>{{ end }}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -415,7 +415,7 @@ p {
     transition: transform var(--transition-speed) ease;
 }
 a.partner-card:hover {
-    transform: translateY(-4px); border-color: rgba(146, 239, 252, 0.25);
+    transform: translateY(-4px); border-color: color-mix(in srgb, var(--accent-color) 25%, transparent);
     box-shadow: 0 12px 24px -16px rgba(2, 12, 27, 0.8);
 }
 a.partner-card:hover::before { transform: scaleX(1); }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -393,33 +393,50 @@ p {
     .certifications .cert-logo { height: 72px; }
 }
 
-/* "Projects, Continued" — a light list of partner repos/sites */
+/* "Projects, Continued" — compact numbered partner cards */
 .partners-intro { max-width: 640px; margin-bottom: 1.5rem; }
-.partners-list {
-    list-style: none; padding: 0; margin: 0;
-    display: flex; flex-wrap: wrap; gap: 12px;
+.partners-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(min(100%, 220px), 1fr));
+    gap: 16px;
 }
-.partners-list li { margin: 0; }
-.partners-list li a,
-.partners-list li .partner-placeholder {
-    display: inline-flex; align-items: center; gap: 8px;
-    font-family: 'Fira Code', monospace; font-size: 0.9rem; font-weight: 500;
-    color: var(--heading-color); text-decoration: none;
+.partner-card {
+    position: relative; overflow: hidden;
+    display: flex; flex-direction: column; gap: 4px;
+    padding: 16px 18px; border-radius: 8px;
     background-color: var(--card-background); border: 1px solid transparent;
-    padding: 8px 16px; border-radius: 999px;
-    transition: color var(--transition-speed) ease, border-color var(--transition-speed) ease, transform var(--transition-speed) ease;
+    text-decoration: none; color: var(--heading-color);
+    transition: transform var(--transition-speed) ease, border-color var(--transition-speed) ease, box-shadow var(--transition-speed) ease;
 }
-.partners-list li a:hover,
-.partners-list li a:focus-visible {
-    color: var(--accent-color); border-color: var(--accent-color); transform: translateY(-2px);
-    outline: none;
+.partner-card::before {
+    content: ''; position: absolute; top: 0; left: 0; right: 0; height: 2px;
+    background: linear-gradient(to right, var(--accent-color), transparent);
+    transform: scaleX(0); transform-origin: left;
+    transition: transform var(--transition-speed) ease;
 }
-.partners-list li a:focus-visible { outline: 2px solid var(--accent-color); outline-offset: 2px; }
-.partners-list li a i,
-.partners-list li .partner-placeholder i { font-size: 0.8rem; color: var(--accent-color); }
-/* Placeholder chips (no real URL yet) read as non-interactive. */
-.partners-list li .partner-placeholder { opacity: 0.55; cursor: default; }
-.partners-list li .partner-placeholder i { color: var(--text-color); }
+a.partner-card:hover {
+    transform: translateY(-4px); border-color: rgba(146, 239, 252, 0.25);
+    box-shadow: 0 12px 24px -16px rgba(2, 12, 27, 0.8);
+}
+a.partner-card:hover::before { transform: scaleX(1); }
+a.partner-card:focus-visible { outline: 2px solid var(--accent-color); outline-offset: 2px; }
+.partner-num {
+    font-family: 'Fira Code', monospace; font-size: 0.78rem;
+    color: var(--accent-color); opacity: 0.85;
+}
+.partner-name {
+    font-family: 'Fira Code', monospace; font-size: 0.98rem; font-weight: 600;
+    color: var(--heading-color);
+}
+.partner-note { font-size: 0.82rem; line-height: 1.4; color: var(--text-color); }
+.partner-arrow {
+    position: absolute; top: 16px; right: 16px; font-size: 0.8rem;
+    color: var(--text-color); opacity: 0; transform: translate(-4px, 2px);
+    transition: opacity var(--transition-speed) ease, transform var(--transition-speed) ease, color var(--transition-speed) ease;
+}
+a.partner-card:hover .partner-arrow { opacity: 1; transform: translate(0, 0); color: var(--accent-color); }
+/* Placeholder cards (no real URL yet) read as non-interactive. */
+.partner-card--placeholder { opacity: 0.5; cursor: default; }
 
 /* Utility for accessible hidden headings */
 .visually-hidden {


### PR DESCRIPTION
## Summary

Redesigns the **"Projects, Continued"** partners section from a flat pill-chip list into a more captivating but compact **numbered card grid**, and gives each entry a short context line.

## Changes

- `layouts/partials/partners.html` — compact numbered cards: `01 / 02 / 03` index, partner name, and a short context/relationship line. Real links render as interactive `<a>` cards with a slide-in arrow; `#` placeholders render as muted, non-interactive cards.
- `static/css/style.css` — replace the pill-chip styles with `.partners-grid` / `.partner-card` styles: `auto-fill` grid (~220px min), accent gradient top-bar + lift + arrow on hover, `:focus-visible` outline, muted placeholder state.
- `hugo.toml` — add a `note` context field to each `params.partners` entry (placeholder copy for now).

## Notes
- Entries are still placeholders (`url = "#"`); swap `name` / `note` / `url` in `hugo.toml` when the real list is ready — no template changes needed.

## Testing
- `hugo --gc` builds cleanly (pre-existing section/taxonomy layout warnings are unrelated).
- Verified the rendered `public/index.html`: the partners section renders three numbered cards with name + context, in placeholder (non-interactive) state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWj4XJtH8LEcPvqENLEyDn)_